### PR TITLE
updating reference labels and making the toc a big <ul>

### DIFF
--- a/rst/dev-guide/_templates/plain/layout.html
+++ b/rst/dev-guide/_templates/plain/layout.html
@@ -1,0 +1,2 @@
+{% block body %}
+{% endblock %}

--- a/rst/dev-guide/_toc.rst
+++ b/rst/dev-guide/_toc.rst
@@ -1,11 +1,31 @@
+* :ref:`overview`
 
-.. toctree::
-   :includehidden:   
-   :maxdepth: 99
+  * :ref:`intended-audience`
+  * :ref:`additional-resources`
+  * :ref:`pricing-service-level`
 
-   index.rst
-   overview/index
-   concepts/index
-   general-api-info/index
-   api-operations/index
-   
+* :ref:`concepts`
+
+  * :ref:`images`
+  * :ref:`image-entities`
+  * :ref:`image-identifiers`
+  * :ref:`common-image-properties`
+  * :ref:`image-sharing`
+  * :ref:`asynchronous-image-tasks`
+  * :ref:`statuses`
+  * :ref:`http-patch-method`
+
+* :ref:`general-api-info`
+
+  * :ref:`send-request-receive-responses`
+  * :ref:`media-types`
+  * :ref:`json-schemas`
+  * :ref:`how-curl-commands-work`
+  * :ref:`authenticate-through-the-rackspace-cloud-identity-service`
+  * :ref:`role-based-access-control`
+  * :ref:`service-access-endpoints`
+
+* :ref:`api-operations`
+
+  * :ref:`api-operations-images`
+  * :ref:`api-operations-image-sharing`

--- a/rst/dev-guide/api-operations/image-2.0/image-sharing-operations.rst
+++ b/rst/dev-guide/api-operations/image-2.0/image-sharing-operations.rst
@@ -1,4 +1,4 @@
-.. _images-api-operations-image-sharing:
+.. _api-operations-image-sharing:
 
 Image sharing
 --------------

--- a/rst/dev-guide/api-operations/image-2.0/images-operations.rst
+++ b/rst/dev-guide/api-operations/image-2.0/images-operations.rst
@@ -1,4 +1,4 @@
-.. _images-api-operations-images:
+.. _api-operations-images:
 
 Images
 --------

--- a/rst/dev-guide/api-operations/index.rst
+++ b/rst/dev-guide/api-operations/index.rst
@@ -1,4 +1,4 @@
-.. _images-dg-api-operations:
+.. _api-operations:
 
 ================
 API Operations
@@ -21,8 +21,8 @@ Developers use the operations described in this chapter to perform the following
 .. include:: api-operations/image-2.0/image-sharing-operations.rst
 
 
-.. toctree:: :hidden:
-   :maxdepth: 2
+.. toctree::
+   :hidden:
 
    image-2.0/images-operations
    image-2.0/image-sharing-operations

--- a/rst/dev-guide/concepts/concepts-topics.rst
+++ b/rst/dev-guide/concepts/concepts-topics.rst
@@ -1,4 +1,4 @@
-.. _ci-concepts-images:
+.. _images:
 
 Images
 ------
@@ -9,10 +9,10 @@ image. The new server will have the same files and operating system that
 the original server had at the time the image was created.
 
 
-The Cloud Images service enables you to use standard, Rackspace-supported images 
-and to create, share, and use nonstandard images that are not supported by Rackspace. 
+The Cloud Images service enables you to use standard, Rackspace-supported images
+and to create, share, and use nonstandard images that are not supported by Rackspace.
 
-.. _ci-concepts-standard-images:
+.. _standard-images:
 
 Standard images
 ~~~~~~~~~~~~~~~
@@ -25,7 +25,7 @@ Standard images include the following images:
 *  All images that have not reached their end of life and that are
    provided specifically for RackConnect customers
 
-.. _ci-concepts-nonstandard-images:
+.. _nonstandard-images:
 
 Nonstandard images
 ~~~~~~~~~~~~~~~~~~
@@ -44,27 +44,27 @@ Nonstandard images include the following images:
 
 .. note::
    This is not an exhaustive list of nonstandard images.
-   
-   
-.. ci-concepts-image-entities:
+
+
+.. _image-entities:
 
 Image entities
 --------------
 
 An image entity is represented by a JSON-encoded data structure and its raw binary data.
 
-An image entity has an identifier (ID) that is guaranteed to be unique within its 
+An image entity has an identifier (ID) that is guaranteed to be unique within its
 endpoint. The ID is used as a token in request URIs to interact with that specific image.
 
-An image is always guaranteed to have the following attributes: id, status, visibility, 
-protected, tags, created_at, file and self. The other attributes defined in the image 
-schema are guaranteed to be defined, but will only be returned with an image entity if 
+An image is always guaranteed to have the following attributes: id, status, visibility,
+protected, tags, created_at, file and self. The other attributes defined in the image
+schema are guaranteed to be defined, but will only be returned with an image entity if
 they have been explicitly set.
 
-A client may set arbitrarily-named attributes on their images if the image json-schema 
+A client may set arbitrarily-named attributes on their images if the image json-schema
 allows it. These user-defined attributes will appear like any other image attributes.
 
-.. _ci-concepts-image-identifiers:
+.. _image-identifiers:
 
 Image identifiers
 -----------------
@@ -83,7 +83,7 @@ where:
 ``{image_ID}``
     The image identifier, which is a *UUID*, making it globally unique
 
-.. _ci-concepts-common-image-properties:
+.. _common-image-properties:
 
 Common image properties
 -----------------------
@@ -96,11 +96,11 @@ options:
 
 **os\_version**
     The operating system version as specified by the distributor
-    
+
 **os\_distro**
     The common name of the operating system distribution
 
-.. important:: The common name of the os\distro must be all lowercase and entered exactly 
+.. important:: The common name of the os\distro must be all lowercase and entered exactly
     as shown here. The allowed values are as follows:
 
     **arch**
@@ -160,7 +160,7 @@ options:
     **windows**
         Microsoft Windows
 
-.. _ci-concepts-image-sharing:
+.. _image-sharing:
 
 Image sharing
 -------------
@@ -236,7 +236,7 @@ Sample workflow for image sharing, after image creation
    address for notification purposes, but this is outside the scope of
    the API.
 
-#. The producer shares the image with the consumer,  by using the 
+#. The producer shares the image with the consumer,  by using the
    *Create image member* API operation.
 
 #. Optionally, the producer notifies the consumer that the image has
@@ -253,7 +253,7 @@ Sample workflow for image sharing, after image creation
    available, the consumer uses the Cloud Images API to change the image
    member status to ``pending``, by using the *Update image member* API operation.
 
-.. _ci-concepts-asynchronous-image-tasks:
+.. _asynchronous-image-tasks:
 
 Asynchronous image tasks
 ------------------------
@@ -263,8 +263,8 @@ operation, such as importing or exporting an image. The request creates
 a disposable task resource that you poll for information about the
 operation's status.
 
-After you initiate an image import or export, poll the task's status by using 
-the *Get task details* API operation repeatedly until the task completes. The 
+After you initiate an image import or export, poll the task's status by using
+the *Get task details* API operation repeatedly until the task completes. The
 “Get details for a task” section of this guide shows an example.
 
 When the poll response has a status of ``success`` or ``failure``, the
@@ -282,7 +282,7 @@ For more information on task statuses, search for "task statuses".
    parameters.
 
    The *Task to import image* and *Task to export image* sections
-   and "POST\exportImage\tasks\Image\Task\" show the Rackspace requirements for these 
+   and "POST\exportImage\tasks\Image\Task\" show the Rackspace requirements for these
    parameters.
 
 High-level process for importing an image
@@ -297,7 +297,7 @@ High-level process for importing an image
    storage and to create a new image for you. This activity takes some
    time.
 
-#. Poll the task status by using the *Get task details* operation repeatedly. The “Get 
+#. Poll the task status by using the *Get task details* operation repeatedly. The “Get
    details for a task” section of this guide shows an example.
 
 High-level process for exporting an image
@@ -305,7 +305,7 @@ High-level process for exporting an image
 
 #. Determine the UUID of the image you want to export.
 
-#. Submit the export request by using the *Task to export image* API operation. The 
+#. Submit the export request by using the *Task to export image* API operation. The
    “Export an image by using tasks” section of this guide shows an example.
 
 #. The Cloud Images service begins to process the image, to convert it
@@ -314,10 +314,10 @@ High-level process for exporting an image
    the exported image to your Cloud Files account. This activity takes
    some time.
 
-#. Poll the task status by using the *Get task details* operation repeatedly. The “Get 
+#. Poll the task status by using the *Get task details* operation repeatedly. The “Get
    details for a task” section of this guide shows an example.
 
-.. _ci-concepts-statuses:
+.. _statuses:
 
 Statuses
 --------
@@ -325,8 +325,6 @@ Statuses
 The Cloud Images API uses a variety of statuses to identify the state of
 images or image components. This section describes the statuses and
 their values.
-
-.. _ci-dg-overview-image-statuses:
 
 Image statuses
 ~~~~~~~~~~~~~~
@@ -451,10 +449,10 @@ Image members can have any of the following statuses.
     available, but this is outside the scope of the Cloud Images API.
 
 .. note::
-   With a ``rejected`` or ``pending``  image member status, the consumer can still use the 
+   With a ``rejected`` or ``pending``  image member status, the consumer can still use the
    image but must know the image ID, since the image is not in the image list.
 
-.. _ci-concepts-http-patch-method:
+.. _http-patch-method:
 
 HTTP PATCH method
 -----------------
@@ -502,7 +500,7 @@ The *ABNF* syntax is as follows:
     reference-token = *( unescaped / escaped )
     unescaped = %x00-2E / %x30-7D / %x7F-10FFFF
     escaped = "~" ( "0" / "1" )
-                        
+
 
 An example of converting image properties to JSON Pointers, which is
 necessary to use the ``HTTP PATCH`` method, is as
@@ -526,8 +524,8 @@ Image Entity:
         "self": "/v2/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea",
         "file": "/v2/images/da3b75d9-3f4a-40e7-8a2c-bfab23927dea/file",
         "schema": "/v2/schemas/image"
-    }             
-                
+    }
+
 
 Comparison of the JSON Pointer to the Image Entity Key Pair:
 
@@ -535,10 +533,10 @@ Comparison of the JSON Pointer to the Image Entity Key Pair:
 
     JSON Pointer        Image Entity Key Pair
      /name          "name":"cirros-0.3.0-x86_64-uec-ramdisk"
-     /size          "size":"2254249"             
+     /size          "size":"2254249"
      /tags          "tags":["ping", "pong"]
-     /~0~1.ssh~1    "~/.ssh/":"present"               
-                
+     /~0~1.ssh~1    "~/.ssh/":"present"
+
 
 Using the HTTP PATCH method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -598,7 +596,7 @@ specified path in the target image. The path must reference an image
 property to add to an existing image. The operation object contains a
 value member that specifies the value to be added.
 
-.. warning:: 
+.. warning::
    There is a small subset of standard image properties that can be
    added by users; please consult the `Rackspace Knowledge Center <http://www.rackspace.com/knowledge_center/>`__ for details. If
    you add any other properties as part of your PATCH request, the
@@ -650,4 +648,3 @@ Replace Example
 .. warning::
    If the specified image property does not exist for the target
    image, an error condition results.
-

--- a/rst/dev-guide/concepts/index.rst
+++ b/rst/dev-guide/concepts/index.rst
@@ -1,4 +1,4 @@
-.. _ci-dg-concepts:
+.. _concepts:
 
 Concepts
 --------
@@ -7,3 +7,8 @@ To understand the Cloud Images service and API, review the following key terms a
 concepts.
 
 .. include:: concepts/concepts-topics.rst
+
+.. toctree::
+   :hidden:
+
+   concepts-topics

--- a/rst/dev-guide/conf.py
+++ b/rst/dev-guide/conf.py
@@ -43,7 +43,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = '_toc'
 
 # General information about the project.
 project = 'Rackspace Developer Portal'

--- a/rst/dev-guide/general-api-info/authenticate.rst
+++ b/rst/dev-guide/general-api-info/authenticate.rst
@@ -1,3 +1,5 @@
+.. _authenticate-through-the-rackspace-cloud-identity-service:
+
 Authenticate through the Rackspace Cloud Identity Service
 ---------------------------------------------------------
 
@@ -20,13 +22,13 @@ For detailed information about the Identity Service v2.0, see the
 Rackspace Cloud Identity Service Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you authenticate, use the following endpoint: 
+When you authenticate, use the following endpoint:
 ``https://identity.api.rackspacecloud.com/v2.0/``
 
 Authentication Request
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To authenticate, issue a **POST** **/tokens** request to the Rackspace Cloud Identity 
+To authenticate, issue a **POST** **/tokens** request to the Rackspace Cloud Identity
 Service endpoint.
 
 In the request body, supply one of the following sets of credentials:
@@ -42,7 +44,7 @@ Rackspace Cloud Control Panel.
    use multi-factor authentication to add an additional level of account
    security. This feature is not implemented for username and API
    credentials. For more information, search for multifactor authentication
-   on the Rackspace site. 
+   on the Rackspace site.
 
 To find your API key, perform the following steps:
 
@@ -80,7 +82,7 @@ Key: JSON Request**
          -H "Content-Type: application/json" | python -m json.tool
 
 
-.. note:: 
+.. note::
    In these examples, the following pipe command makes the JSON output
    more readable:
    ::
@@ -118,21 +120,21 @@ format:
                 {
                     "endpoints": [
                         {
-                            "internalURL": "https://snet-storage101.dfw1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7", 
-                            "publicURL": "https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7", 
-                            "region": "DFW", 
+                            "internalURL": "https://snet-storage101.dfw1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7",
+                            "publicURL": "https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7",
+                            "region": "DFW",
                             "tenantId": "MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7"
-                        }, 
+                        },
                         {
-                            "internalURL": "https://snet-storage101.ord1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7", 
-                            "publicURL": "https://storage101.ord1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7", 
-                            "region": "ORD", 
+                            "internalURL": "https://snet-storage101.ord1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7",
+                            "publicURL": "https://storage101.ord1.clouddrive.com/v1/MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7",
+                            "region": "ORD",
                             "tenantId": "MossoCloudFS_530f8649-324c-499c-a075-2195854d52a7"
                         }
-                    ], 
-                    "name": "cloudFiles", 
+                    ],
+                    "name": "cloudFiles",
                     "type": "object-store"
-                }, 
+                },
  				{
         			"endpoints": [
           				{
@@ -165,44 +167,44 @@ format:
         			"type": "image"
       			},
                 {
-                    "endpoints": [ 
+                    "endpoints": [
                         {
-                            "publicURL": "https://dfw.servers.api.rackspacecloud.com/v2/010101", 
-                            "region": "DFW", 
-                            "tenantId": "010101", 
-                            "versionId": "2", 
-                            "versionInfo": "https://dfw.servers.api.rackspacecloud.com/v2", 
+                            "publicURL": "https://dfw.servers.api.rackspacecloud.com/v2/010101",
+                            "region": "DFW",
+                            "tenantId": "010101",
+                            "versionId": "2",
+                            "versionInfo": "https://dfw.servers.api.rackspacecloud.com/v2",
                             "versionList": "https://dfw.servers.api.rackspacecloud.com/"
-                        }, 
+                        },
                         {
-                            "publicURL": "https://ord.servers.api.rackspacecloud.com/v2/010101", 
-                            "region": "ORD", 
-                            "tenantId": "010101", 
-                            "versionId": "2", 
-                            "versionInfo": "https://ord.servers.api.rackspacecloud.com/v2", 
+                            "publicURL": "https://ord.servers.api.rackspacecloud.com/v2/010101",
+                            "region": "ORD",
+                            "tenantId": "010101",
+                            "versionId": "2",
+                            "versionInfo": "https://ord.servers.api.rackspacecloud.com/v2",
                             "versionList": "https://ord.servers.api.rackspacecloud.com/"
                         }
-                    ], 
-                    "name": "cloudServersOpenStack", 
+                    ],
+                    "name": "cloudServersOpenStack",
                     "type": "compute"
                 }
-            ], 
+            ],
             "token": {
-                "expires": "2012-09-14T15:11:57.585-05:00", 
-                "id": "858fb4c2-bf15-4dac-917d-8ec750ae9baa", 
+                "expires": "2012-09-14T15:11:57.585-05:00",
+                "id": "858fb4c2-bf15-4dac-917d-8ec750ae9baa",
                 "tenant": {
-                    "id": "010101", 
+                    "id": "010101",
                     "name": "010101"
                 }
-            }, 
+            },
             "user": {
-                "RAX-AUTH:defaultRegion": "DFW", 
-                "id": "170454", 
-                "name": "MyRackspaceAcct", 
+                "RAX-AUTH:defaultRegion": "DFW",
+                "id": "170454",
+                "name": "MyRackspaceAcct",
                 "roles": [
                     {
-                        "description": "User Admin Role.", 
-                        "id": "3", 
+                        "description": "User Admin Role.",
+                        "id": "3",
                         "name": "identity:user-admin"
                     }
                 ]
@@ -248,7 +250,7 @@ Locate the correct service name in the service catalog, as follows:
    special considerations for choosing a data center at
    http://ord.admin.kc.rakr.net/knowledge_center/article/about-regions.
 
-If you use the authentication token to access this service, you can perform Cloud Images 
+If you use the authentication token to access this service, you can perform Cloud Images
 API operations.
 
 **Expiration date and time for authentication token**. Appears in the
@@ -270,7 +272,7 @@ element.
 You pass the authentication token in the ``X-Auth-Token`` header each
 time that you send a request to a service.
 
-Once you have your authentication token and your endpoint you are ready to send a 
+Once you have your authentication token and your endpoint you are ready to send a
 request to the Cloud Images service.
 
 In the following example, you first export the tenant ID, ``010101``, to the

--- a/rst/dev-guide/general-api-info/general-api-topics.rst
+++ b/rst/dev-guide/general-api-info/general-api-topics.rst
@@ -1,50 +1,49 @@
-.. _images-dg-gen-info-send-request-receive-response:
+.. _send-request-receive-responses:
 
 Sending API requests and receiving responses
 --------------------------------------------
 
-You have several options for sending requests through an API: 
+You have several options for sending requests through an API:
 
-- Developers and testers might prefer to use cURL with the command-line tool from 
+- Developers and testers might prefer to use cURL with the command-line tool from
   http://curl.haxx.se/.
-  
-  For more information about using cURL, search for "cURL commands".
-  
-- If you like to use a more graphical interface, the REST client for Mozilla Firefox also 
-  works well for testing and trying out commands. See 
-  https://addons.mozilla.org/en-US/firefox/addon/restclient/.
-  
-  Similar browser plug-ins are available for browsers other than Firefox.
-  
-.. note::
-   If you use a browser plug-in, be sure to include the Header elements for ``Content-Type`` 
-   and ``X-Auth-Token`` with appropriate values.
-   
-- You can download and install RESTclient, a Java application for testing ReSTful web 
-  services, from http://code.google.com/p/rest-client/. 
 
-.. _images-dg-gen-info-media-types:
+  For more information about using cURL, search for "cURL commands".
+
+- If you like to use a more graphical interface, the REST client for Mozilla Firefox also
+  works well for testing and trying out commands. See
+  https://addons.mozilla.org/en-US/firefox/addon/restclient/.
+
+  Similar browser plug-ins are available for browsers other than Firefox.
+
+.. note::
+   If you use a browser plug-in, be sure to include the Header elements for ``Content-Type``
+   and ``X-Auth-Token`` with appropriate values.
+
+- You can download and install RESTclient, a Java application for testing ReSTful web
+  services, from http://code.google.com/p/rest-client/.
+
+.. _media-types:
 
 Media Types
 -----------
 
-The Cloud Images API accepts and serves JSON-encoded data. The media type required in the 
-request varies by the following request types: 
+The Cloud Images API accepts and serves JSON-encoded data. The media type required in the
+request varies by the following request types:
 
-- Requests that send **JSON-encoded data** use the following media type in their 
+- Requests that send **JSON-encoded data** use the following media type in their
   ``Content-Type header: 'application/json'``.
 
-- Requests that use **HTTP PATCH syntax** use the following media type in their 
+- Requests that use **HTTP PATCH syntax** use the following media type in their
   ``Content-Type header: 'application/openstack-images-v2.1-json-patch'``.
 
 
-.. _images-dg-gen-info-json-schemas:
+.. _json-schemas:
 
 JSON Schemas
 ------------
 
-The necessary JSON-schema documents are provided at predictable URIs. A consumer 
-validates server responses and client requests based on the published schemas. The 
-schemas contained in this document are only examples and should not be used to validate 
+The necessary JSON-schema documents are provided at predictable URIs. A consumer
+validates server responses and client requests based on the published schemas. The
+schemas contained in this document are only examples and should not be used to validate
 your requests. A client should always fetch current schemas from the server.
-

--- a/rst/dev-guide/general-api-info/how-curl-commands-work.rst
+++ b/rst/dev-guide/general-api-info/how-curl-commands-work.rst
@@ -1,26 +1,26 @@
-.. _ci-dg-generalapi-curl:
+.. _how-curl-commands-work:
 
 
 ======================
 How cURL commands work
 ======================
 
-cURL is a command-line tool that you can use to interact with REST interfaces. cURL lets 
-you to transmit and receive HTTP requests and responses from the command line or a shell 
-script, which enables you to work with the API directly. It is available for Linux distributions, 
+cURL is a command-line tool that you can use to interact with REST interfaces. cURL lets
+you to transmit and receive HTTP requests and responses from the command line or a shell
+script, which enables you to work with the API directly. It is available for Linux distributions,
 Mac OS X, and Windows. For information about cURL, see http://curl.haxx.se/.
 
-To run the cURL request examples shown in this guide, copy each example from the HTML version 
+To run the cURL request examples shown in this guide, copy each example from the HTML version
 of this guide directly to the command line or a script.
 
 .. _cn-dg-generalapi-curl-json:
 
-The following command is an example cURL command that provisions a server with an isolated 
+The following command is an example cURL command that provisions a server with an isolated
 network using JSON.
 
 **cURL command example: JSON request**
 
-.. code::  
+.. code::
 
                 $ curl https://dfw.servers.api.rackspacecloud.com/v2/$account/servers \
            -X POST \
@@ -33,7 +33,7 @@ network using JSON.
 
 ..  note::
 
-    The carriage returns in the cURL request examples use a backslash (``\``) as an escape 
+    The carriage returns in the cURL request examples use a backslash (``\``) as an escape
     character. The escape character allows continuation of the command across multiple lines.
 
 The cURL examples in this guide use the following command-line options.
@@ -62,7 +62,7 @@ The cURL examples in this guide use the following command-line options.
 |           | ``X-Auth-Token``: Required.                                           |
 |           |                                                                       |
 |           | - Specifies the authentication token.                                 |
-|           |                                                                       |       
+|           |                                                                       |
 |           | ``X-Auth-Project-Id``: Optional.                                      |
 |           |                                                                       |
 |           | - Specifies the project ID, which can be your account number or       |
@@ -93,19 +93,19 @@ The cURL examples in this guide use the following command-line options.
 +-----------+-----------------------------------------------------------------------+
 
 
-For commands that return a response, use json.tool to pretty-print the output by 
+For commands that return a response, use json.tool to pretty-print the output by
 appending the following command to the cURL call:
 
-.. code::  
+.. code::
 
    | python -m json.tool
 
 ..  note::
 
-    To use json.tool, import the JSON module. For information about json.tool, see 
+    To use json.tool, import the JSON module. For information about json.tool, see
     `JSON encoder and decoder`_.
 
-    If you run a Python version earlier than 2.6, import the simplejson module and use 
+    If you run a Python version earlier than 2.6, import the simplejson module and use
     simplejson.tool. For information about simplejson.tool, see `simplejson encoder and decoder`_.
 
     If you do not want to pretty-print JSON output, omit this code.

--- a/rst/dev-guide/general-api-info/index.rst
+++ b/rst/dev-guide/general-api-info/index.rst
@@ -1,4 +1,4 @@
-.. _images-dg-general-api-info
+.. _general-api-info:
 
 General API Information
 -----------------------
@@ -18,3 +18,13 @@ The Cloud Images API supports JSON data serialization request and response forma
 .. include:: general-api-info/authenticate.rst
 .. include:: general-api-info/role-based-access-control.rst
 .. include:: general-api-info/service-access-endpoints.rst
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   general-api-topics
+   how-curl-commands-work
+   authenticate
+   role-based-access-control
+   service-access-endpoints

--- a/rst/dev-guide/general-api-info/role-based-access-control.rst
+++ b/rst/dev-guide/general-api-info/role-based-access-control.rst
@@ -1,3 +1,5 @@
+.. _role-based-access-control:
+
 Role Based Access Control
 -------------------------
 
@@ -38,7 +40,7 @@ to perform the following tasks:
 Roles Available for Cloud Images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Three roles (observer, creator, and admin) can be used to access the Cloud Images API 
+Three roles (observer, creator, and admin) can be used to access the Cloud Images API
 specifically. The following section describes these roles and their permissions.
 
 **Cloud Images Product Roles and Permissions**
@@ -49,8 +51,8 @@ specifically. The following section describes these roles and their permissions.
 
 - **cloudImages:observer** This role provides Read permission in Cloud Images, where access is granted.
 
-Additionally, two multiproduct roles apply to all products. Users with multiproduct roles 
-inherit access to future products when those products become RBAC-enabled. The following 
+Additionally, two multiproduct roles apply to all products. Users with multiproduct roles
+inherit access to future products when those products become RBAC-enabled. The following
 section describes these roles and their permissions.
 
 **Multiproduct (Global) Roles and Permissions**
@@ -63,13 +65,13 @@ section describes these roles and their permissions.
 Resolving Conflicts Between Roles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The account owner can set roles for both multiproduct and Cloud Images scope, and it is 
-important to understand how any potential conflicts among these roles are resolved. When 
+The account owner can set roles for both multiproduct and Cloud Images scope, and it is
+important to understand how any potential conflicts among these roles are resolved. When
 two roles appear to conflict, the role that provides the more extensive permissions takes
-precedence. Therefore, admin roles take precedence over observer and creator roles, because 
+precedence. Therefore, admin roles take precedence over observer and creator roles, because
 admin roles provide more permissions.
 
-The following scenarios show examples of how potential conflicts between user roles in the 
+The following scenarios show examples of how potential conflicts between user roles in the
 Control Panel are resolved:
 
 
@@ -88,13 +90,12 @@ cloudImages **observer**
 
 *Control Panel View:* Appears that the user has only the multiproduct **admin** role.
 
-Permissions: The user can perform product admin functions in the control panel for all of the products. 
+Permissions: The user can perform product admin functions in the control panel for all of the products.
 The Cloud Images **observer** role is ignored.
 
 RBAC Permissions Cross-reference to Cloud Images API Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-API operations for Cloud Images may or may not be available to all roles. To see which 
+API operations for Cloud Images may or may not be available to all roles. To see which
 operations are permitted to invoke which calls, please review `the Knowledge Center
 article <http://www.rackspace.com/knowledge_center/article/detailed-permissions-matrix-for-cloud-images>`__.
-

--- a/rst/dev-guide/general-api-info/service-access-endpoints.rst
+++ b/rst/dev-guide/general-api-info/service-access-endpoints.rst
@@ -1,3 +1,5 @@
+.. _service-access-endpoints:
+
 Service access endpoints
 ------------------------
 
@@ -36,4 +38,3 @@ environments.
    If you do not know your account ID or which data center you are
    working in, you can find that information in your Cloud Control Panel at
    `mycloud.rackspace.com. <http://mycloud.rackspace.com>`__
-

--- a/rst/dev-guide/overview/additional-resources.rst
+++ b/rst/dev-guide/overview/additional-resources.rst
@@ -1,3 +1,5 @@
+.. _additional-resources:
+
 Additional resources
 ---------------------
 

--- a/rst/dev-guide/overview/index.rst
+++ b/rst/dev-guide/overview/index.rst
@@ -1,4 +1,4 @@
-.. _ci-dg-overview:
+.. _overview:
 
 Overview
 --------
@@ -6,3 +6,10 @@ Overview
 .. include:: overview/intended-audience.rst
 .. include:: overview/additional-resources.rst
 .. include:: overview/pricing-service-level.rst
+
+.. toctree::
+   :hidden:
+
+   intended-audience
+   additional-resources
+   pricing-service-level

--- a/rst/dev-guide/overview/intended-audience.rst
+++ b/rst/dev-guide/overview/intended-audience.rst
@@ -1,3 +1,5 @@
+.. _intended-audience:
+
 Intended Audience
 -----------------
 

--- a/rst/dev-guide/overview/pricing-service-level.rst
+++ b/rst/dev-guide/overview/pricing-service-level.rst
@@ -1,12 +1,11 @@
-.. _ci-dg-pricing-service-level
+.. _pricing-service-level:
 
 Rackspace pricing and terms of service
 --------------------------------------
 
-Cloud Images is part of the Rackspace cloud and your use of the Cloud Images API will be 
+Cloud Images is part of the Rackspace cloud and your use of the Cloud Images API will be
 billed according to the schedule at http://www.rackspace.com/cloud/images.
 
-Periodically review the Rackspace Cloud Terms of Service for your 
-Terms of Service because they can be updated any time. These documents also include 
+Periodically review the Rackspace Cloud Terms of Service for your
+Terms of Service because they can be updated any time. These documents also include
 the Acceptable Use Policies.
-


### PR DESCRIPTION
@meker12 @annegentle I'd appreciate your input on this.

Presenting this document as a single page using `include` statements seems to be working well, but when generating the toctree, I found that Sphinx still thinks the content is spread out over several pages. The only way I was able to get the master ToC to work was to build a nested unordered list full of links to the reference labels that precede each section, instead of using the built-in `toctree` directive.

**Cons with that approach:**

* Writers must manually add a reference label to each section throughout the documentation.
* Writers must manually add links to the sections they want to appear in the ToC
* The WADL2RST content doesn't have reference labels, so it's not linkable. This can be fixed in that converter, though.

**Pros:**

* It works.
* Allows more control over the appearance of the ToC regardless of how Sphinx wants to structure/nest the content sections.